### PR TITLE
fix/readme-tables: Fix formatting on markdown tables

### DIFF
--- a/packages/animate/README.md
+++ b/packages/animate/README.md
@@ -17,7 +17,7 @@ import Animate from '@hixme-ui/animate'
 Add any animation from [https://daneden.github.io/animate.css/](Animate.css) as a boolean prop.
 
 | Name            | Type        |
----------------------------------
+| --------------- | ----------- |
 | time            | string      |
 | delay           | string      |
 | count           | string      |

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -16,7 +16,7 @@ import Input from '@hixme-ui/input'
 ## Props
 
 | Name            | Type        |
----------------------------------
+| --------------- | ----------- |
 | textarea        | bool        |
 | phone           | bool        |
 | date            | bool        |

--- a/packages/separator/README.md
+++ b/packages/separator/README.md
@@ -16,7 +16,7 @@ import Separator from '@hixme-ui/separator'
 ## Props
 
 | Name            | Type        |
----------------------------------
+| --------------- | ----------- |
 | height          | string      |
 | margin          | string      |
 | padding         | string      |


### PR DESCRIPTION
Should fix the formatting for markdown tables in the README's