### PR TITLE
fix/checkbox: Move styled components to own files

### DIFF
--- a/packages/checkbox/src/Checkbox.js
+++ b/packages/checkbox/src/Checkbox.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+
+import StyledCheckbox from './StyledCheckbox'
+import StyledFakeCheckbox from './StyledFakeCheckbox'
+import StyledLabel from './StyledLabel'
 
 export default class Checkbox extends Component {
   static displayName = 'hui:Checkbox'
@@ -67,58 +70,6 @@ export default class Checkbox extends Component {
 
   /* eslint-disable jsx-a11y/label-has-for */
   render() {
-    const StyledCheckbox = styled.input`
-      position: fixed;
-      left: -9999px;
-      top: -9999px;
-      &:checked ~ {
-        &:after {
-          opacity: 1 !important;
-        }
-      }
-      &:focus ~ {
-        outline: none;
-        border-color: #2fb699;
-        box-shadow: 0 0 10px #2fb699;
-      }
-    `
-
-    const StyledFakeCheckbox = styled.span`
-      cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
-      border-radius: 3px;
-      border: 1px solid #b9c5cd;
-      width: ${props => (props.small ? '15px' : '18px')};
-      height: ${props => (props.small ? '15px' : '18px')};
-      display: inline-block;
-      vertical-align: top;
-      position: relative;
-      background: white;
-      font-size: 0;
-      line-height: 0;
-      &:after {
-        position: absolute;
-        left: ${props => (props.small ? '3px' : '4px')};
-        top: 4px;
-        content: '';
-        border: ${props => (props.disabled ? '2px solid #B9C5CD' : '2px solid #2eae8f')};
-        border-top: none;
-        border-right: none;
-        width: ${props => (props.small ? '8px' : '9px')};
-        height: ${props => (props.small ? '4px' : '5px')};
-        opacity: 0;
-        transform: rotate(-45deg);
-        transition: all .2s ease-in-out;
-      }
-    `
-
-    const StyledLabel = styled.span`
-      cursor: pointer;
-      display: inline-block;
-      color: #4a5b64;
-      margin: 0 0 0 16px;
-      vertical-align: top;
-    `
-
     return (
       <label>
         <StyledCheckbox type='checkbox' {...this.getProps()} />

--- a/packages/checkbox/src/StyledCheckbox.js
+++ b/packages/checkbox/src/StyledCheckbox.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components'
+
+const StyledCheckbox = styled.input`
+  position: fixed;
+  left: -9999px;
+  top: -9999px;
+  &:checked ~ {
+    &:after {
+      opacity: 1 !important;
+    }
+  }
+  &:focus ~ {
+    outline: none;
+    border-color: #2fb699;
+    box-shadow: 0 0 10px #2fb699;
+  }
+`
+
+export default StyledCheckbox

--- a/packages/checkbox/src/StyledFakeCheckbox.js
+++ b/packages/checkbox/src/StyledFakeCheckbox.js
@@ -1,0 +1,31 @@
+import styled from 'styled-components'
+
+const StyledFakeCheckbox = styled.span`
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
+  border-radius: 3px;
+  border: 1px solid #b9c5cd;
+  width: ${props => (props.small ? '15px' : '18px')};
+  height: ${props => (props.small ? '15px' : '18px')};
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  background: white;
+  font-size: 0;
+  line-height: 0;
+  &:after {
+    position: absolute;
+    left: ${props => (props.small ? '3px' : '4px')};
+    top: 4px;
+    content: '';
+    border: ${props => (props.disabled ? '2px solid #B9C5CD' : '2px solid #2eae8f')};
+    border-top: none;
+    border-right: none;
+    width: ${props => (props.small ? '8px' : '9px')};
+    height: ${props => (props.small ? '4px' : '5px')};
+    opacity: 0;
+    transform: rotate(-45deg);
+    transition: all .2s ease-in-out;
+  }
+`
+
+export default StyledFakeCheckbox

--- a/packages/checkbox/src/StyledLabel.js
+++ b/packages/checkbox/src/StyledLabel.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+
+const StyledLabel = styled.span`
+  cursor: pointer;
+  display: inline-block;
+  color: #4a5b64;
+  margin: 0 0 0 16px;
+  vertical-align: top;
+`
+
+export default StyledLabel

--- a/packages/checkbox/src/index.js
+++ b/packages/checkbox/src/index.js
@@ -1,3 +1,7 @@
 import Checkbox from './Checkbox'
 
+export StyledCheckbox from './StyledCheckbox'
+export StyledFakeCheckbox from './StyledFakeCheckbox'
+export StyledLabel from './StyledLabel'
+
 export default Checkbox


### PR DESCRIPTION
Declaring the styled-components inside Checkbox was causing some weird bugs on documentation pages.