### PR TITLE
fix/remove-babel: replace babel with babel-cli

### DIFF
--- a/packages/animate/package.json
+++ b/packages/animate/package.json
@@ -42,7 +42,6 @@
     "David Cotelessa"
   ],
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -42,7 +42,6 @@
     "David Cotelessa"
   ],
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",
@@ -78,7 +77,7 @@
     "husky": "^0.13.3",
     "jest": "^21.2.1",
     "mocha": "^3.3.0",
-    "react-addons-test-utils": "^15.0.0",
+    "react-addons-test-utils": "^15.6.2",
     "react-test-renderer": "^15.6.2",
     "regenerator-runtime": "^0.11.0",
     "rimraf": "^2.6.1",
@@ -88,12 +87,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@hixme-ui/theme": "^1.3.0",
-    "@hixme-ui/theme-props": "^1.3.0",
     "prop-types": "^15.6.0",
-    "react": "^15.6.1",
-    "react-animations": "^1.0.0",
-    "react-maskedinput": "^4.0.0",
-    "styled-components": "^2.2.2"
+    "react": "^16.2.0",
+    "styled-components": "^2.3.3"
   }
 }

--- a/packages/content-container/package.json
+++ b/packages/content-container/package.json
@@ -43,7 +43,6 @@
   ],
   "devDependencies": {
     "@hixme-ui/theme": "^1.3.0",
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/form-group/package.json
+++ b/packages/form-group/package.json
@@ -42,7 +42,6 @@
     "David Cotelessa"
   ],
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -42,7 +42,6 @@
     "David Cotelessa"
   ],
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/phone/package.json
+++ b/packages/phone/package.json
@@ -43,7 +43,6 @@
   ],
   "devDependencies": {
     "@hixme-ui/theme": "^1.3.0",
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -42,7 +42,6 @@
     "David Cotelessa"
   ],
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/separator/package.json
+++ b/packages/separator/package.json
@@ -42,7 +42,6 @@
     "David Cotelessa"
   ],
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/social-security/package.json
+++ b/packages/social-security/package.json
@@ -43,7 +43,6 @@
   ],
   "devDependencies": {
     "@hixme-ui/theme": "^1.3.0",
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -43,7 +43,6 @@
   ],
   "devDependencies": {
     "@hixme-ui/theme": "^1.3.0",
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",

--- a/packages/title/package.json
+++ b/packages/title/package.json
@@ -43,7 +43,6 @@
   ],
   "devDependencies": {
     "@hixme-ui/theme": "^1.3.0",
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.0.0-beta.6",


### PR DESCRIPTION
My development environment will not work unless I remove babel. Everything appears to work now after removing babel as a dev dependency. Please test this on your development machines and let me know if everything still works.