### PR TITLE
fix/text-size-inherit: Add inherit fall through on Text fontSize property

### DIFF
--- a/packages/text/src/TextBase.js
+++ b/packages/text/src/TextBase.js
@@ -9,7 +9,7 @@ import {
 const TextBase = styled.span`
   color: ${props => props.color || getTextColor(props)};
   font-family: ${props => props.fontFamily || getFontFamily(props)};
-  font-size: ${props => props.fontSize || getFontSize(props)};
+  font-size: ${props => props.fontSize || getFontSize(props, 'inherit')};
   font-weight: ${props => props.fontWeight || getFontWeight(props)};
   border-bottom: ${(props) => {
     if (props.dashed) return '1px dashed'


### PR DESCRIPTION
Fix intended to alleviate problems arising from usage like this:

```jsx
<Title>
  Some Title:
  <Text bold>With styles modified by Text</Text>
</Title>
```