### PR TITLE
fix/block-menu-button: Remove display: inline-block on MenuButtonContainer

### DIFF
--- a/packages/button/src/MenuButton.js
+++ b/packages/button/src/MenuButton.js
@@ -19,7 +19,6 @@ const toggleButtonStyles = {
 }
 
 const MenuButtonContainer = styled.div`
- display: inline-flex;
  justify-content: center;
  position: relative;
  white-space: nowrap;


### PR DESCRIPTION
The assignment of inline-flex is breaking the block prop for menu buttons