### PR TITLE
fix/block-menu-button

### DIFF
--- a/packages/button/src/MenuButton.js
+++ b/packages/button/src/MenuButton.js
@@ -19,9 +19,10 @@ const toggleButtonStyles = {
 }
 
 const MenuButtonContainer = styled.div`
- justify-content: center;
- position: relative;
- white-space: nowrap;
+  display: flex;
+  justify-content: center;
+  position: relative;
+  white-space: nowrap;
 `
 
 class MenuButton extends Component {

--- a/packages/button/src/MenuButton.js
+++ b/packages/button/src/MenuButton.js
@@ -19,7 +19,6 @@ const toggleButtonStyles = {
 }
 
 const MenuButtonContainer = styled.div`
- display: inline-flex;
  justify-content: center;
  position: relative;
  white-space: nowrap;

--- a/packages/button/src/MenuButton.js
+++ b/packages/button/src/MenuButton.js
@@ -29,16 +29,18 @@ class MenuButton extends Component {
   static displayName = 'MenuButton'
 
   static propTypes = {
-    onClick: PropTypes.func,
+    block: PropTypes.bool,
     children: PropTypes.string,
     contentComponent: PropTypes.func,
+    onClick: PropTypes.func,
     split: PropTypes.bool,
   }
 
   static defaultProps = {
-    onClick: null,
+    block: false,
     children: '',
     contentComponent: () => null,
+    onClick: null,
     split: false,
   }
 
@@ -77,7 +79,7 @@ class MenuButton extends Component {
   }
 
   render() {
-    const { split, onClick, children, contentComponent, ...rest } = this.props
+    const { split, onClick, children, contentComponent, block, ...rest } = this.props
     const hasMini = Object.keys(this.props).includes('mini')
     const ContentComponent = contentComponent
 
@@ -87,6 +89,7 @@ class MenuButton extends Component {
           outline
           style={split ? mainButtonStyles : null}
           onClick={split ? onClick : this.handleTrigger}
+          block={block}
           {...rest}
         >
           {children}

--- a/packages/hui-pages/src/routes/ButtonDocs/index.js
+++ b/packages/hui-pages/src/routes/ButtonDocs/index.js
@@ -91,7 +91,7 @@ const ButtonDocs = () => (
           </Button>
         </div>
         <div style={padded}>
-          <Button light menu contentComponent={SplitContent}>
+          <Button light menu contentComponent={SplitContent} block>
             Menu Button light
           </Button>
         </div>

--- a/packages/hui-pages/src/routes/ButtonDocs/index.js
+++ b/packages/hui-pages/src/routes/ButtonDocs/index.js
@@ -91,7 +91,7 @@ const ButtonDocs = () => (
           </Button>
         </div>
         <div style={padded}>
-          <Button light menu contentComponent={SplitContent} block>
+          <Button light menu contentComponent={SplitContent}>
             Menu Button light
           </Button>
         </div>


### PR DESCRIPTION
Revise flex properties to restore `block` functionality to MenuButton and SplitButton