### PR TITLE
fix/text-default-color

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "lerna run lint --parallel --no-sort ",
     "test": "lerna run test --no-sort --ignore hui-pages",
     "refresh": "npm run clean && npm run bootstrap",
-    "deploy": "cd ./packages/hui-pages && npm run deploy"
+    "deploy": "cd ./packages/hui-pages && npm run deploy",
+    "start": "cd ./packages/hui-pages && npm start"
   }
 }

--- a/packages/text/src/TextBase.js
+++ b/packages/text/src/TextBase.js
@@ -7,7 +7,7 @@ import {
 } from '@hixme-ui/theme-props'
 
 const TextBase = styled.span`
-  color: ${props => props.color || getTextColor(props)};
+  color: ${props => props.color || getTextColor(props, 'inherit')};
   font-family: ${props => props.fontFamily || getFontFamily(props)};
   font-size: ${props => props.fontSize || getFontSize(props, 'inherit')};
   font-weight: ${props => props.fontWeight || getFontWeight(props)};


### PR DESCRIPTION
Because the textColors have a default color, the inherit property wasn't getting through from the top level of the theme props. 