### PR TITLE
imp/RadioButtonCentering: Corrects vertical alignment

### DIFF
--- a/packages/radio-button/src/RadioButton.js
+++ b/packages/radio-button/src/RadioButton.js
@@ -27,7 +27,7 @@ const RadioText = LabelBase.extend`
   cursor: pointer;
   display: inline-block;
   font-weight: 500;
-  font: 500 16px/18px;
+  font: 500 14px;
   color: #4a5b64;
   margin: 0 0 0 16px;
   max-width: calc(100% - 46px);
@@ -46,6 +46,7 @@ const RadioDisplay = styled.span`
   font-size: 0;
   line-height: 0;
   vertical-align: top;
+  top: 2px;
   &:after {
     position: absolute;
     left: 2px;
@@ -90,4 +91,3 @@ RadioButton.propTypes = {
 }
 
 export default RadioButton
-


### PR DESCRIPTION
Just a nitpick: this centers the text vertically. Before on the right-side, after on the left.

<img width="1256" alt="screen shot 2018-07-10 at 9 45 17 pm" src="https://user-images.githubusercontent.com/3869095/42551175-dceb2c6c-848a-11e8-9566-267997faa4c7.png">
