### PR TITLE
imp/ThemeButtonMinWidths

### DIFF
--- a/packages/hui-pages/src/routes/ButtonDocs/index.js
+++ b/packages/hui-pages/src/routes/ButtonDocs/index.js
@@ -31,7 +31,7 @@ const ButtonDocs = () => (
           <Button mini>mini</Button>
         </div>
         <div style={padded}>
-          <Button blue small>blue small</Button>
+          <Button blue small>small</Button>
         </div>
         <div style={padded}>
           <Button secondary>secondary</Button>

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -65,10 +65,10 @@ const buttonHeights = {
 
 const buttonMinWidths = {
   mini: '80px',
-  small: '80px',
-  default: '100px',
-  large: '100px',
-  jumbo: '100px',
+  small: '100px',
+  default: '120px',
+  large: '140px',
+  jumbo: '160px',
 }
 
 const buttonTextColors = {


### PR DESCRIPTION
You won't need to re-size the default buttons (to prevent size changes/jumps) when using loadingText