### PR TITLE
fix/theme-jest-dep: Add jest devDependency to theme package

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -67,6 +67,7 @@
     "extract-text-webpack-plugin": "^1.0.0",
     "flow-bin": "^0.45.0",
     "husky": "^0.13.3",
+    "jest": "^21.2.1",
     "react-addons-test-utils": "^15.0.0",
     "react-test-renderer": "^16.0.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Ran into some trouble bootstrapping a fresh install of the hixme-ui because of this missing dev dependency.